### PR TITLE
Ignore vulnerabilities from the Apache Avro library 1.11.3 version

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# Apache Commons Vulnerability (remove once the fixed version for Apache Avro is delivered)
+CVE-2024-25710
+CVE-2024-26308

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ export=["confluent.cregistry"]
 keywords = ["confluent", "schema_registry", "avro", "serdes"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-confluent.cregistry"
 license = ["Apache-2.0"]
-distribution = "2201.8.2"
+distribution = "2201.8.6"
 
 [platform.java17]
 graalvmCompatible = true
@@ -27,8 +27,8 @@ path = "./lib/kafka-schema-registry-client-5.3.2.jar"
 [[platform.java17.dependency]]
 groupId = "io.confluent"
 artifactId = "common-config"
-version = "4.1.0"
-path = "./lib/common-config-4.1.0.jar"
+version = "5.3.0"
+path = "./lib/common-config-5.3.0.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.confluent"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ export=["confluent.cregistry"]
 keywords = ["confluent", "schema_registry", "avro", "serdes"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-confluent.cregistry"
 license = ["Apache-2.0"]
-distribution = "2201.8.2"
+distribution = "2201.8.6"
 
 [platform.java17]
 graalvmCompatible = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.lib
 version=0.1.0-SNAPSHOT
-ballerinaLangVersion=2201.8.2
+ballerinaLangVersion=2201.8.6
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=5.0.14

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ avroVersion=1.11.3
 kafkaAvroVersion=5.3.0
 kafkaClientVersion=3.7.0
 kafkaSchemaRegistryVersion=5.3.2
-commonConfigVersion=4.1.0
+commonConfigVersion=5.3.0
 commonUtilsVersion=5.3.0


### PR DESCRIPTION
## Purpose
> $subject

[The latest Apache Avro library version (1.11.3)](https://mvnrepository.com/artifact/org.apache.avro/avro/1.11.3) contains vulnerabilities identified by the [Trivy scanner](https://github.com/ballerina-platform/module-ballerinax-confluent.cregistry/actions/runs/8626563697/job/23644924281#step:9:70). Currently ignore them as there are no fixes for that yet.