### PR TITLE
Update jackson-databind to 2.18.8 to fix trivy vulnerabilities

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,7 @@
 # Apache Commons Vulnerability (remove once the fixed version for Apache Avro is delivered)
 CVE-2024-25710
 CVE-2024-26308
+
+# jackson-databind CVEs fixed only in 2.18.9, which FasterXML has not yet published to Maven Central (remove once 2.18.9 is released and the dependency is bumped)
+CVE-2026-54514
+CVE-2026-54515

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "confluent.cregistry"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Ballerina"]
 keywords = ["Messaging/Schema Registry", "Cost/Freemium", "Vendor/Confluent", "Area/Messaging", "Type/Connector"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-confluent.cregistry"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "schema-registry-native"
-version = "0.4.4"
-path = "../native/build/libs/confluent.cregistry-native-0.4.4.jar"
+version = "0.4.5"
+path = "../native/build/libs/confluent.cregistry-native-0.4.5-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.confluent"
@@ -51,20 +51,20 @@ path = "./lib/avro-1.11.4.jar"
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-core"
-version = "2.18.6"
-path = "./lib/jackson-core-2.18.6.jar"
+version = "2.18.8"
+path = "./lib/jackson-core-2.18.8.jar"
 
 [[platform.java11.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-annotations"
-version = "2.18.6"
-path = "./lib/jackson-annotations-2.18.6.jar"
+version = "2.18.8"
+path = "./lib/jackson-annotations-2.18.8.jar"
 
 [[platform.java11.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-databind"
-version = "2.18.6"
-path = "./lib/jackson-databind-2.18.6.jar"
+version = "2.18.8"
+path = "./lib/jackson-databind-2.18.8.jar"
 
 [[platform.java11.dependency]]
 groupId = "com.google.guava"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 jacocoVersion=0.8.10
 
-jacksonVersion=2.18.6
+jacksonVersion=2.18.8
 avroVersion=1.11.4
 kafkaAvroVersion=5.3.0
 kafkaClientVersion=3.9.1


### PR DESCRIPTION
## Summary
- Bumps `jacksonVersion` in `gradle.properties` from `2.18.6` to `2.18.8`, fixing CVE-2026-54512 and CVE-2026-54513 (HIGH — jackson-databind PolymorphicTypeValidator bypass RCEs)
- `ballerina/Ballerina.toml` regenerated via `./gradlew updateTomlFiles` to reflect the new `jackson-core`/`jackson-annotations`/`jackson-databind` versions

## Known remaining gap
The two MEDIUM CVEs (CVE-2026-54514, CVE-2026-54515) are fixed upstream only in `jackson-databind 2.18.9`, which FasterXML has not yet published to Maven Central as of this PR (confirmed against `repo1.maven.org` and Maven Central's `maven-metadata.xml` — latest published 2.18.x is `2.18.8`; the `2.18` branch on `FasterXML/jackson-databind` is still at `2.18.9-SNAPSHOT`). These two CVEs are suppressed in `.trivyignore` with a comment noting they should be removed once `2.18.9` is released and this dependency bumped again.

## Test plan
- [ ] CI build (`pull-request.yml`) passes
- [ ] Trivy scan passes with only the two documented, ignored MEDIUM CVEs remaining
- [ ] Existing Ballerina test suite (`ballerina/tests/test.bal`) passes unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Jackson dependency stack to version 2.18.8 and regenerated the Ballerina package metadata so the recorded artifact versions stay aligned across Gradle and Ballerina.toml.

Also updated Trivy ignore entries for two remaining upstream issues that are not yet covered by the next Jackson release, with a note to remove the suppression once that version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->